### PR TITLE
Fixed issue where comparison with None fails

### DIFF
--- a/imagehash/__init__.py
+++ b/imagehash/__init__.py
@@ -61,8 +61,10 @@ class ImageHash(object):
 		return repr(self.hash)
 
 	def __sub__(self, other):
-		assert other is not None, ('Other hash must not be None!')
-		assert self.hash.shape == other.hash.shape, ('ImageHashes must be of the same shape!', self.hash.shape, other.hash.shape)
+		if other is None:
+			raise TypeError('Other hash must not be None.')
+		if self.hash.shape != other.hash.shape:
+			raise TypeError('ImageHashes must be of the same shape.', self.hash.shape, other.hash.shape)
 		return (self.hash != other.hash).sum()
 
 	def __eq__(self, other):


### PR DESCRIPTION
Comparison with `None` fails as `__eq__` expects `other` to be a `ImageHash` instance. Example:

```
>>> d = imagehash.dhash(pil_image)
>>> d == None
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/path/to/project/imagehash/__init__.py", line 68, in __eq__
    return numpy.array_equal(self.hash, other.hash)
AttributeError: 'NoneType' object has no attribute 'hash'
```

This commit fixes that for `__eq__`, `__ne__` and `__sub__`.
