### PR TITLE
Continue even if scipy.fftpack is missing

### DIFF
--- a/imagehash/__init__.py
+++ b/imagehash/__init__.py
@@ -32,8 +32,17 @@ Rotation by 26: 21 Hamming difference
 
 from PIL import Image
 import numpy
-import scipy.fftpack
 
+"""
+Try to import the scipy.fftpack module. If it is not available pHash will not work, but one can still use aHash and dHash.
+"""
+try:
+	import scipy.fftpack
+	havefftpack = True
+except ImportError:
+	havefftpack = False
+
+	
 def binary_array_to_hex(arr):
 	h = 0
 	s = []
@@ -116,6 +125,9 @@ Implementation follows http://www.hackerfactor.com/blog/index.php?/archives/432-
 @image must be a PIL instance.
 """
 def phash(image, hash_size=32):
+	if (havefftpack == False):
+		import scipy.fftpack
+		
 	image = image.convert("L").resize((hash_size, hash_size), Image.ANTIALIAS)
 	pixels = numpy.array(image.getdata(), dtype=numpy.float).reshape((hash_size, hash_size))
 	dct = scipy.fftpack.dct(pixels)


### PR DESCRIPTION
Unfortunately so is scipy.fftpack unavailable on some systems. Mainly ActivePython on Windows. 

However since scipy.fftpack is only used in the pHash function one could cache the error and still allow the user to use aHash and dHash. The attached code tries to import the scipy.fftpack module. If it is not available pHash will not work (pHash will fail on importing  scipy.fftpack in the pHash function if called. This to show the user what import failed), but users can still use aHash and dHash.
