### PR TITLE
Rebuild the phash algorithm

### DIFF
--- a/imagehash/__init__.py
+++ b/imagehash/__init__.py
@@ -19,7 +19,7 @@ False
 >>> for r in range(1, 30, 5):
 ...     rothash = imagehash.average_hash(Image.open('test.png').rotate(r))
 ...     print('Rotation by %d: %d Hamming difference' % (r, hash - rothash))
-... 
+...
 Rotation by 1: 2 Hamming difference
 Rotation by 6: 11 Hamming difference
 Rotation by 11: 13 Hamming difference
@@ -45,7 +45,7 @@ def binary_array_to_hex(arr):
 	return "".join(s)
 
 def binary_array_to_int(arr):
-	return sum([2**(i % 8) for i,v in enumerate(arr.flatten()) if v])
+	return sum([2**i for i,v in enumerate(arr.flatten()) if v])
 
 """
 Hash encapsulation. Can be used for dictionary keys and comparisons.
@@ -116,10 +116,10 @@ Implementation follows http://www.hackerfactor.com/blog/index.php?/archives/432-
 def phash(image, hash_size=32):
 	image = image.convert("L").resize((hash_size, hash_size), Image.ANTIALIAS)
 	pixels = numpy.array(image.getdata(), dtype=numpy.float).reshape((hash_size, hash_size))
-	dct = scipy.fftpack.dct(pixels)
-	dctlowfreq = dct[:8, 1:9]
-	avg = dctlowfreq.mean()
-	diff = dctlowfreq > avg
+	dct = scipy.fftpack.dct(scipy.fftpack.dct(pixels, axis=0), axis=1)
+	dctlowfreq = dct[:8, :8]
+	med = numpy.median(dctlowfreq)
+	diff = dctlowfreq > med
 	return ImageHash(diff)
 
 """

--- a/imagehash/__init__.py
+++ b/imagehash/__init__.py
@@ -45,7 +45,7 @@ def binary_array_to_hex(arr):
 	return "".join(s)
 
 def binary_array_to_int(arr):
-	return sum([2**i for i,v in enumerate(arr.flatten()) if v])
+	return sum([2**(i % 8) for i,v in enumerate(arr.flatten()) if v])
 
 """
 Hash encapsulation. Can be used for dictionary keys and comparisons.
@@ -117,9 +117,25 @@ def phash(image, hash_size=32):
 	image = image.convert("L").resize((hash_size, hash_size), Image.ANTIALIAS)
 	pixels = numpy.array(image.getdata(), dtype=numpy.float).reshape((hash_size, hash_size))
 	dct = scipy.fftpack.dct(scipy.fftpack.dct(pixels, axis=0), axis=1)
-	dctlowfreq = dct[:8, :8]
+	dctlowfreq = dct[:int(hash_size/4), :int(hash_size/4)]
 	med = numpy.median(dctlowfreq)
 	diff = dctlowfreq > med
+	return ImageHash(diff)
+
+"""
+Perceptual Hash computation.
+
+Implementation follows http://www.hackerfactor.com/blog/index.php?/archives/432-Looks-Like-It.html
+
+@image must be a PIL instance.
+"""
+def phash_simple(image, hash_size=32):
+	image = image.convert("L").resize((hash_size, hash_size), Image.ANTIALIAS)
+	pixels = numpy.array(image.getdata(), dtype=numpy.float).reshape((hash_size, hash_size))
+	dct = scipy.fftpack.dct(pixels)
+	dctlowfreq = dct[:8, 1:9]
+	avg = dctlowfreq.mean()
+	diff = dctlowfreq > avg
 	return ImageHash(diff)
 
 """

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('README.rst') as f:
 
 setup(
     name='ImageHash',
-    version='0.3',
+    version='0.4',
     author='Johannes Buchner',
     author_email='buchner.johannes@gmx.at',
     packages=['imagehash'],


### PR DESCRIPTION
For experiments and reasoning, see: JohannesBuchner/imagehash/issues/13

Changes to phash() algorithm:
   - use a bi-directional DCT
   - use the median instead of the mean of coefficients
   - use all the low-frequency coefficients instead of skipping a column

Also includes a fix for binary_array_to_int()