### PR TITLE
Make imagehash version available.

### DIFF
--- a/imagehash/__init__.py
+++ b/imagehash/__init__.py
@@ -37,6 +37,9 @@ import numpy
 #import pywt
 
 
+__version__ = '3.1'
+
+
 def _binary_array_to_hex(arr):
 	"""
 	internal function to make a hex string out of a binary array

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,20 @@ long_description = ""
 with open('README.rst') as f:
     long_description = f.read()
 
+def extract_version():
+    fname = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                         'imagehash', '__init__.py')
+    with open(fname) as fi:
+        for line in fi:
+            if (line.startswith('__version__')):
+                _, version = line.split('=')
+                version = version.strip()[1:-1]  # Removes quotation.
+                break
+    return version
+
 setup(
     name='ImageHash',
-    version='3.1',
+    version=extract_version(),
     author='Johannes Buchner',
     author_email='buchner.johannes@gmx.at',
     packages=['imagehash', 'imagehash.tests'],


### PR DESCRIPTION
@JohannesBuchner Okay, so I'm going to guess that you will push back on this PR, but I'd really,really like to argue my case for it's inclusion, because I really think it's of significant value ...

At the moment it's not possible for a user or developer to easily tell which version of `imagehash` they are using. Note that, not everyone has admin rights and `imagehash` may be deployed on their system or virtual environment not through their involvement.

It's important to know the software stack that you're using, and it's common place to discover this e.g.
```python
>>> import matplotlib
>>> matplotlib.__version__
'1.5.3'
>>> 
```
```python
>>> numpy.__version__
'1.11.2'
>>> 
```
The reason that users of `imagehash` can't easily tell the version is simply because the version is baked into the `setup.py`, which is fine ... but it prevents a user from discovering it.

Adopting the standard `imagehash.__init__.__version__` approach solves this problem, and it is a problem if you want users in the community to report issues on the software but can't tell what version they are using.

The addition to the `setup.py` for this PR is a really simple function to get the value of the `__version__` variable in the `imagehash.__init__`.

So when it comes to bumping the version of `imagehash` you only need to update the `imagehash.__init__.__version__` variable and `setup.py` maintains consistency for deployment.