### PR TITLE
Do not read version from file for pyinstaller compatibility

### DIFF
--- a/imagehash/__init__.py
+++ b/imagehash/__init__.py
@@ -36,8 +36,8 @@ import numpy
 #import scipy.fftpack
 #import pywt
 import os.path
-__version__ = open(os.path.join(os.path.abspath(
-	os.path.dirname(__file__)), 'VERSION')).read().strip()
+#__version__ = open(os.path.join(os.path.abspath(
+#	os.path.dirname(__file__)), 'VERSION')).read().strip()
 
 def _binary_array_to_hex(arr):
 	"""


### PR DESCRIPTION
Pyinstaller do not add VERSION file to distribution and module import fails