### PR TITLE
Flatten hash(es) before comparing in ImageHas.__sub__()

### DIFF
--- a/imagehash/__init__.py
+++ b/imagehash/__init__.py
@@ -77,7 +77,7 @@ class ImageHash(object):
 			raise TypeError('Other hash must not be None.')
 		if self.hash.size != other.hash.size:
 			raise TypeError('ImageHashes must be of the same shape.', self.hash.shape, other.hash.shape)
-		return numpy.count_nonzero(self.hash != other.hash)
+		return numpy.count_nonzero(self.hash.flatten() != other.hash.flatten())
 
 	def __eq__(self, other):
 		if other is None:


### PR DESCRIPTION
Fix for method __sub__(self, other) of ImageHash:
When self.hash is not flattened, and other.hash is flattened,  'self - other' would return 1 while 0 expected.
This error occurs when hash_size is 16.

Example code for testing:
```python
  onehash = imagehash.phash(some_image, 16)                  
  anotherhash = hex_to_hash(str(onehash), 16) 
  #  diff should be 0
  diff = onehash - anotherhash 
```
    