### PR TITLE
Improve speed for arr to hex and hex to arr conversions.

### DIFF
--- a/imagehash/__init__.py
+++ b/imagehash/__init__.py
@@ -44,9 +44,9 @@ __version__ = open(os.path.join(os.path.abspath(
 
 def _binary_array_to_hex(arr):
 	"""
-	internal function to make a hex string out of a binary array.
+	internal function to make a hex string out of a numpy 2D bool array.
 	"""
-	bit_string = ''.join(str(b) for b in 1 * arr.flatten())
+	bit_string = arr.astype('u1').astype('S1').tostring()
 	width = int(numpy.ceil(len(bit_string)/4))
 	return '{:0>{width}x}'.format(int(bit_string, 2), width=width)
 
@@ -97,10 +97,11 @@ def hex_to_hash(hexstr):
 	2. This algorithm does not work for hash_size < 2.
 	"""
 	hash_size = int(numpy.sqrt(len(hexstr)*4))
-	binary_array = '{:0>{width}b}'.format(int(hexstr, 16), width = hash_size * hash_size)
-	bit_rows = [binary_array[i:i+hash_size] for i in range(0, len(binary_array), hash_size)]
-	hash_array = numpy.array([[bool(int(d)) for d in row] for row in bit_rows])
-	return ImageHash(hash_array)
+	binary_str = bin(int(hexstr, 16))[2:]
+	arr = numpy.asarray([x for x in reversed(binary_str)], dtype='u1').astype('?')
+	arr.resize(hash_size * hash_size)
+	arr = numpy.flip(arr, axis=0).reshape((hash_size, hash_size))
+	return ImageHash(arr)
 
 def old_hex_to_hash(hexstr, hash_size=8):
 	"""

--- a/imagehash/__init__.py
+++ b/imagehash/__init__.py
@@ -100,7 +100,7 @@ def hex_to_hash(hexstr):
 	binary_str = bin(int(hexstr, 16))[2:]
 	arr = numpy.asarray([x for x in reversed(binary_str)], dtype='u1').astype('?')
 	arr.resize(hash_size * hash_size)
-	arr = numpy.flip(arr, axis=0).reshape((hash_size, hash_size))
+	arr = numpy.flipud(arr).reshape((hash_size, hash_size))
 	return ImageHash(arr)
 
 def old_hex_to_hash(hexstr, hash_size=8):
@@ -195,7 +195,7 @@ def dhash(image, hash_size=8):
 	Difference Hash computation.
 
 	following http://www.hackerfactor.com/blog/index.php?/archives/529-Kind-of-Like-That.html
-	
+
 	computes differences horizontally
 
 	@image must be a PIL instance.
@@ -232,7 +232,7 @@ def dhash_vertical(image, hash_size=8):
 def whash(image, hash_size = 8, image_scale = None, mode = 'haar', remove_max_haar_ll = True):
 	"""
 	Wavelet Hash computation.
-	
+
 	based on https://www.kaggle.com/c/avito-duplicate-ads-detection/
 
 	@image must be a PIL instance.
@@ -276,4 +276,3 @@ def whash(image, hash_size = 8, image_scale = None, mode = 'haar', remove_max_ha
 	med = numpy.median(dwt_low)
 	diff = dwt_low > med
 	return ImageHash(diff)
-

--- a/imagehash/__init__.py
+++ b/imagehash/__init__.py
@@ -195,7 +195,6 @@ def dhash(image, hash_size=8):
 	Difference Hash computation.
 
 	following http://www.hackerfactor.com/blog/index.php?/archives/529-Kind-of-Like-That.html
-
 	computes differences horizontally
 
 	@image must be a PIL instance.
@@ -216,7 +215,6 @@ def dhash_vertical(image, hash_size=8):
 	Difference Hash computation.
 
 	following http://www.hackerfactor.com/blog/index.php?/archives/529-Kind-of-Like-That.html
-
 	computes differences vertically
 
 	@image must be a PIL instance.
@@ -276,3 +274,4 @@ def whash(image, hash_size = 8, image_scale = None, mode = 'haar', remove_max_ha
 	med = numpy.median(dwt_low)
 	diff = dwt_low > med
 	return ImageHash(diff)
+


### PR DESCRIPTION
As the title says.

```
import numpy as np
from imagehash import _binary_array_to_hex, _binary_array_to_hex_old
from imagehash import hex_to_hash, hex_to_hash_old
import timeit
import random


test_arrays = [np.random.rand(8, 8) > np.full((8,8), 0.5) for i in range(100)]
all([_binary_array_to_hex(x) == _binary_array_to_hex_old(x) for x in test_arrays])
#True
%timeit [_binary_array_to_hex(x) for x in test_arrays]
#3.41 ms ± 66.6 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
%timeit [_binary_array_to_hex_old(x) for x in test_arrays]
#5.47 ms ± 102 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)


hexes = [_binary_array_to_hex_old(x) for x in test_arrays]
all([hex_to_hash(x) == hex_to_hash_old(x) for x in hexes])
#True
%timeit [hex_to_hash(x) for x in hexes]
#2.13 ms ± 33.3 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
%timeit [hex_to_hash_old(x) for x in hexes]
#3.72 ms ± 38.7 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```