### PR TITLE
Fix ResourceWarning

### DIFF
--- a/imagehash/__init__.py
+++ b/imagehash/__init__.py
@@ -38,8 +38,9 @@ import numpy
 #import scipy.fftpack
 #import pywt
 import os.path
-__version__ = open(os.path.join(os.path.abspath(
-	os.path.dirname(__file__)), 'VERSION')).read().strip()
+with open(os.path.join(os.path.abspath(
+	os.path.dirname(__file__)), 'VERSION')) as fi:
+	__version__ = fi.read().strip()
 
 
 def _binary_array_to_hex(arr):


### PR DESCRIPTION
This PR address the issue reported when using Python3.7 and the latest `imagehash` version `4.0` i.e.,
```shell
<snip>/python3.7/site-packages/imagehash/__init__.py:42: ResourceWarning: unclosed file <_io.TextIOWrapper name='<snip>/python3.7/site-packages/imagehash/VERSION' mode='r' encoding='UTF-8'>
  os.path.dirname(__file__)), 'VERSION')).read().strip()
ResourceWarning: Enable tracemalloc to get the object allocation traceback

``` 
