### PR TITLE
Replace out of date link with archive

### DIFF
--- a/imagehash/__init__.py
+++ b/imagehash/__init__.py
@@ -129,7 +129,7 @@ def average_hash(image, hash_size=8):
 
 	Implementation follows http://www.hackerfactor.com/blog/index.php?/archives/432-Looks-Like-It.html
 
-	Step by step explanation: https://www.safaribooksonline.com/blog/2013/11/26/image-hashing-with-python/
+	Step by step explanation: https://web.archive.org/web/20171112054354/https://www.safaribooksonline.com/blog/2013/11/26/image-hashing-with-python/
 
 	@image must be a PIL instance.
 	"""


### PR DESCRIPTION
The original link resulted in a 301 Moved Permanently to https://www.oreilly.com/radar/. I replaced it with a link to the archived version of the website when the blog entry still existed.