### PR TITLE
Improve hash-to-string conversion performance

### DIFF
--- a/imagehash.py
+++ b/imagehash.py
@@ -73,14 +73,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 def _binary_array_to_hex(arr):
 	"""
-	Convert a 2D binary array of bools to a hex string.
+	Encode a 2D ndarray of bools as a hex string.
 	"""
 	hash_int = 0
-
 	for bit in map(int, numpy.nditer(arr)):
 		hash_int = hash_int << 1 | bit
 
-	return "{:x}".format(hash_int)
+	q, mod = divmod(arr.size, 4)
+	width = q + int(mod != 0) # account for leading zeroes
+	
+	return "{:0>{width}x}".format(hash_int, width=width)
 
 
 class ImageHash(object):

--- a/imagehash.py
+++ b/imagehash.py
@@ -71,6 +71,17 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """
 
+def _binary_array_to_hex(arr):
+	"""
+	Convert a 2D binary array of bools to a hex string.
+	"""
+	hash_int = 0
+
+	for bit in map(int, numpy.nditer(arr)):
+		hash_int = hash_int << 1 | bit
+
+	return "{:x}".format(hash_int)
+
 
 class ImageHash(object):
 	"""
@@ -80,12 +91,7 @@ class ImageHash(object):
 		self.hash = binary_array
 
 	def __str__(self):
-		hash_int = 0
-
-		for bit in map(int, numpy.nditer(self.hash)):
-			hash_int = hash_int << 1 | bit
-
-		return f"{hash_int:x}"
+		_binary_array_to_hex(self.hash)
 
 	def __repr__(self):
 		return repr(self.hash)

--- a/imagehash.py
+++ b/imagehash.py
@@ -91,7 +91,7 @@ class ImageHash(object):
 		self.hash = binary_array
 
 	def __str__(self):
-		_binary_array_to_hex(self.hash)
+		return _binary_array_to_hex(self.hash)
 
 	def __repr__(self):
 		return repr(self.hash)

--- a/imagehash.py
+++ b/imagehash.py
@@ -72,15 +72,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 
-def _binary_array_to_hex(arr):
-	"""
-	internal function to make a hex string out of a binary array.
-	"""
-	bit_string = ''.join(str(b) for b in 1 * arr.flatten())
-	width = int(numpy.ceil(len(bit_string)/4))
-	return '{:0>{width}x}'.format(int(bit_string, 2), width=width)
-
-
 class ImageHash(object):
 	"""
 	Hash encapsulation. Can be used for dictionary keys and comparisons.
@@ -89,7 +80,12 @@ class ImageHash(object):
 		self.hash = binary_array
 
 	def __str__(self):
-		return _binary_array_to_hex(self.hash.flatten())
+		hash_int = 0
+
+		for bit in map(int, numpy.nditer(self.hash)):
+			hash_int = hash_int << 1 | bit
+
+		return f"{hash_int:x}"
 
 	def __repr__(self):
 		return repr(self.hash)


### PR DESCRIPTION
Hi there,

Noticed some inefficiencies in string conversion code and tried to improve it a bit. In my highly scientific™ test results it performs about 3-3.5x faster on average.

Test results of converting 84 hashes of real data 2000 times:

```
Number of hashes: 84
Hash matrix dimensions: 8x8
Original version: 16.906992000000173
Updated version: 5.23041590000048
Encoded hex strings are identical:  True
```

I opted for an f-string which might raise some backwards compatibility concerns, let me know if you want it changed. Other than that I don't think this should cause any regressions.

Hope it helps.