### PR TITLE
Added function phash_faster using opencv

### DIFF
--- a/imagehash.py
+++ b/imagehash.py
@@ -216,6 +216,29 @@ def phash(image, hash_size=8, highfreq_factor=4):
 	return ImageHash(diff)
 
 
+def phash_faster(self, image, hash_size=8, highfreq_factor=4):
+        """
+	Perceptual Hash computation.
+
+	Implementation follows http://www.hackerfactor.com/blog/index.php?/archives/432-Looks-Like-It.html
+
+	@image must be a Numpy array/OpenCV instance.
+	"""
+        if hash_size < 2:
+            raise ValueError("Hash size must be greater than or equal to 2")
+
+        import scipy.fft
+        import cv2
+        img_size = hash_size * highfreq_factor
+        image = cv2.cvtColor(image, cv2.COLOR_RGB2GRAY)
+        image = cv2.resize(image, (img_size, img_size), interpolation=cv2.INTER_LINEAR)
+        dct = scipy.fft.dct(scipy.fft.dct(image, axis=0), axis=1)
+        dctlowfreq = dct[:hash_size, :hash_size]
+        med = np.median(dctlowfreq)
+        diff = dctlowfreq > med
+        return ImageHash(diff)
+
+
 def phash_simple(image, hash_size=8, highfreq_factor=4):
 	"""
 	Perceptual Hash computation.


### PR DESCRIPTION
Hi
I recently wrote a program for video comparing done frame by frame and I used ImageHash for phash computing, but the default phash function was immensely slow; more specifically the `convert` and `resize` functions of PIL and `numpy.asarray()` were the problem. 
So I rewrote those parts with OpenCV and in my case the result was 10-15 times faster.
I thought of replacing `phash` function entirely, but it would be inconsistent with rest of the project. So I added another function (`phash_faster`) and although importing `cv2` inside the function makes it call each time which is not the best idea, it also makes it an unnecessary dependency.

It is possible to get same PIL instance as input then convert it to array using `numpy.asarray` and only replace PIL functions with OpenCV, but still it will be too slow and defeats the purpose. 

If continuing with PIL is not necessary I suggest to convert all other PIL dependencies to OpenCV.