### PR TITLE
Added packaging module (requirement for Python 3.5)

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,7 +21,7 @@ jobs:
           sudo apt-get install -y imagemagick
       - name: Install testing dependencies
         run: |
-          conda install -c anaconda --file conda-requirements.txt flake8 pytest coveralls coverage
+          conda install -c anaconda --file conda-requirements.txt flake8 setuptools pytest coveralls coverage
       - name: Conda info
         run: |
           conda info

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,7 +21,7 @@ jobs:
           sudo apt-get install -y imagemagick
       - name: Install testing dependencies
         run: |
-          conda install -c anaconda --file conda-requirements.txt flake8 pip pytest coveralls coverage
+          conda install -c anaconda --file conda-requirements.txt flake8 packaging pytest coveralls coverage
       - name: Conda info
         run: |
           conda info

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,7 +21,7 @@ jobs:
           sudo apt-get install -y imagemagick
       - name: Install testing dependencies
         run: |
-          conda install -c anaconda --file conda-requirements.txt flake8 setuptools pytest coveralls coverage
+          conda install -c anaconda --file conda-requirements.txt flake8 pip pytest coveralls coverage
       - name: Conda info
         run: |
           conda info

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,7 +9,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.9]
+        python-version: [2.7, 3.5, 3.6, 3.9]
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2


### PR DESCRIPTION
It seems that `packaging` module is not available by default with Python 3.5.