### PR TITLE
Use official OSI name in the license metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     data_files=[('images', ['tests/data/imagehash.png'])],
     scripts=['find_similar_images.py'],
     url='https://github.com/JohannesBuchner/imagehash',
-    license='BSD 2-clause (see LICENSE file)',
+    license='2-clause BSD License',
     description='Image Hashing library',
     long_description=long_description,
     long_description_content_type='text/x-rst',


### PR DESCRIPTION
This makes it easier for automatic license checkers to verify the license of this package.

The license file is included in MANIFEST.in as is standard practice.