### PR TITLE
Improve runtime performance of crop resistant hash

### DIFF
--- a/imagehash.py
+++ b/imagehash.py
@@ -492,7 +492,7 @@ def _find_region(remaining_pixels, segmented_pixels):
 			]
 			try_next.update(neighbours)
 		# Remove pixels we have already seen
-		try_next.difference_update(segmented_pixels, not_in_region)
+		try_next = {x for x in try_next if x not in segmented_pixels and x not in not_in_region}
 		# If there's no more pixels to try, the region is complete
 		if not try_next:
 			break


### PR DESCRIPTION
The difference_update method is pretty slow when the sets in the argument are larger than the initial set.
In this case the **segmented_pixels** set is much larger than **try_next**.

The test runner time for **test_crop_resistant_hash** went down from 17s to 4.5s on my machine.