### PR TITLE
ImageHash accept base 16 string in init

### DIFF
--- a/imagehash.py
+++ b/imagehash.py
@@ -86,6 +86,8 @@ class ImageHash(object):
 	Hash encapsulation. Can be used for dictionary keys and comparisons.
 	"""
 	def __init__(self, binary_array):
+		if isinstance(binary_array, str):
+			binary_array = np.array([int(c) for c in bin(int(binary_array, 16))[2:]])
 		self.hash = binary_array
 
 	def __str__(self):


### PR DESCRIPTION
Accepting string makes it trivial to create ImageHash objects from hash strings created by other hash libraries.

Can do 
```python
imagehash.ImageHash( hashlib.md5(img_np.data).hexdigest() )
```
after this modification.

This way all hashes from other hash libs can support the same operations as hashes creates by imagehash.