### PR TITLE
Create ImageHash from b16 str

### DIFF
--- a/imagehash.py
+++ b/imagehash.py
@@ -88,6 +88,10 @@ class ImageHash(object):
 	def __init__(self, binary_array):
 		self.hash = binary_array
 
+	@classmethod
+	def from_str(cls, b16str):
+		return cls(numpy.array([int(c) for c in bin(int(b16str, 16))[2:].zfill(len(b16str) * 4)]))
+
 	def __str__(self):
 		return _binary_array_to_hex(self.hash.flatten())
 


### PR DESCRIPTION
With this addition we can do 

```python
hash = imagehash.ImageHash.from_str( hashlib.md5(img_np.data).hexdigest() )
```

This way it's easy to create ImageHash from digest generated by other hash libs. Makes processing hashes more uniform.