### PR TITLE
Added hex_to_multihash to recover saved ImageMultiHash

### DIFF
--- a/imagehash.py
+++ b/imagehash.py
@@ -157,9 +157,9 @@ def hex_to_multihash(hexstr):
 	   or onedimensional arrays with dimensions binbits * 14.
 	2. This algorithm does not work for hash_size < 2.
 	"""
-    	split = hexstr.split(',')
-    	hashes = [imagehash.hex_to_hash(x) for x in split]
-    	return imagehash.ImageMultiHash(hashes)
+	split = hexstr.split(',')
+	hashes = [hex_to_hash(x) for x in split]
+	return ImageMultiHash(hashes)
 
 
 def old_hex_to_hash(hexstr, hash_size=8):

--- a/imagehash.py
+++ b/imagehash.py
@@ -145,6 +145,19 @@ def hex_to_flathash(hexstr, hashsize):
 	hash_array = numpy.array([[bool(int(d)) for d in binary_array]])[-hash_size * hashsize:]
 	return ImageHash(hash_array)
 
+def hex_to_multihash(hexstr):
+	"""
+	Convert a stored multihash (hex, as retrieved from str(ImageMultiHash))
+	back to an ImageMultiHash object. 
+	
+	This function is based on hex_to_hash so the same caveats apply.
+	
+	
+	"""
+    	hexstr = hexstr.replace('"', '')
+    	split = hexstr.split(',')
+    	hashes = [imagehash.hex_to_hash(x) for x in split]
+    	return imagehash.ImageMultiHash(hashes)
 
 
 def old_hex_to_hash(hexstr, hash_size=8):

--- a/imagehash.py
+++ b/imagehash.py
@@ -150,11 +150,13 @@ def hex_to_multihash(hexstr):
 	Convert a stored multihash (hex, as retrieved from str(ImageMultiHash))
 	back to an ImageMultiHash object. 
 	
-	This function is based on hex_to_hash so the same caveats apply.
+	This function is based on hex_to_hash so the same caveats apply. Namely:
 	
-	
+	1. This algorithm assumes all hashes are either
+	   bidimensional arrays with dimensions hash_size * hash_size,
+	   or onedimensional arrays with dimensions binbits * 14.
+	2. This algorithm does not work for hash_size < 2.
 	"""
-    	hexstr = hexstr.replace('"', '')
     	split = hexstr.split(',')
     	hashes = [imagehash.hex_to_hash(x) for x in split]
     	return imagehash.ImageMultiHash(hashes)

--- a/imagehash/__init__.py
+++ b/imagehash/__init__.py
@@ -194,10 +194,10 @@ def hex_to_multihash(hexstr):
 	# type: (str) -> ImageMultiHash
 	"""
 	Convert a stored multihash (hex, as retrieved from str(ImageMultiHash))
-	back to an ImageMultiHash object. 
-	
+	back to an ImageMultiHash object.
+
 	This function is based on hex_to_hash so the same caveats apply. Namely:
-	
+
 	1. This algorithm assumes all hashes are either
 			bidimensional arrays with dimensions hash_size * hash_size,
 			or onedimensional arrays with dimensions binbits * 14.

--- a/imagehash/__init__.py
+++ b/imagehash/__init__.py
@@ -189,7 +189,9 @@ def hex_to_flathash(hexstr, hashsize):
 	hash_array = numpy.array([[bool(int(d)) for d in binary_array]])[-hash_size * hashsize:]
 	return ImageHash(hash_array)
 
+
 def hex_to_multihash(hexstr):
+	# type: (str) -> ImageMultiHash
 	"""
 	Convert a stored multihash (hex, as retrieved from str(ImageMultiHash))
 	back to an ImageMultiHash object. 
@@ -197,13 +199,14 @@ def hex_to_multihash(hexstr):
 	This function is based on hex_to_hash so the same caveats apply. Namely:
 	
 	1. This algorithm assumes all hashes are either
-	   bidimensional arrays with dimensions hash_size * hash_size,
-	   or onedimensional arrays with dimensions binbits * 14.
+			bidimensional arrays with dimensions hash_size * hash_size,
+			or onedimensional arrays with dimensions binbits * 14.
 	2. This algorithm does not work for hash_size < 2.
 	"""
 	split = hexstr.split(',')
 	hashes = [hex_to_hash(x) for x in split]
 	return ImageMultiHash(hashes)
+
 
 def old_hex_to_hash(hexstr, hash_size=8):
 	# type: (str, int) -> ImageHash

--- a/tests/test_hex_conversions_multihash.py
+++ b/tests/test_hex_conversions_multihash.py
@@ -1,0 +1,25 @@
+from __future__ import (absolute_import, division, print_function)
+
+import unittest
+from datetime import datetime
+
+import imagehash
+from .utils import TestImageHash
+
+class Test (TestImageHash):
+    def setUp(self):
+        self.image = self.get_data_image()
+
+    def test_hex_to_multi_hash(self):
+        generated_hash = imagehash.crop_resistant_hash(self.image,min_segment_size= 500,segmentation_image_size=1000)
+        #options above are required such that it delivers a true multi image hash with multiple segments
+        string = str(generated_hash)
+        emsg = ('Stringified multihash did not match original hash')
+        self.assertEqual(
+            generated_hash,
+            imagehash.hex_to_multihash(string),
+            emsg
+        )
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_hex_conversions_multihash.py
+++ b/tests/test_hex_conversions_multihash.py
@@ -20,6 +20,13 @@ class Test (TestImageHash):
             imagehash.hex_to_multihash(string),
             emsg
         )
+        string = '0026273b2b19550e,6286373334662535,6636192c47639573,999d6d67a3e82125,27a327c38191a4ad,938971382b328a46'
+        emsg = ('Stringified multihash did not match hardcoded original hash')
+        self.assertEqual(
+            generated_hash,
+            imagehash.hex_to_multihash(string),
+            emsg
+        )
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR adds hex_to_multihash which recovers an ImageMultiHash object after being cast with str()
This would also solve #160 by offering a method to recover saved crop-resistant hashes. 