### PR TITLE
Added Python2 compatible type hints

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -5,4 +5,4 @@ tag = True
 
 [bumpversion:file:setup.py]
 
-[bumpversion:file:imagehash.py]
+[bumpversion:file:imagehash/__init__.py]

--- a/.coveragerc
+++ b/.coveragerc
@@ -5,7 +5,7 @@
 [run]
 branch = True
 include = 
-        imagehash.py
+        imagehash/__init__.py
         find_similar_images.py
 
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         python-version: [2.7, 3.5, 3.6, 3.9]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,6 +33,7 @@ jobs:
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - run: python setup.py install
+      - name: Test install from setup.py
+        run: pip install .
       - run: coverage run -m pytest .
       - run: COVERALLS_REPO_TOKEN=mEQ4sldJtlrG3RzjGVD32EYrjUIj4YCV3 coveralls

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ clean-doc:
 	rm -rf docs/build
 
 lint: ## check style with flake8
-	flake8 imagehash.py tests
+	flake8 imagehash/__init__.py tests
 
 test: ## run tests quickly with the default Python
 	pytest

--- a/imagehash/py.typed
+++ b/imagehash/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.  The imagehash package uses inline types.

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     install_requires=[
         "six",
         "numpy",
-        'scipy',       # for phash
+        "scipy",       # for phash
         "pillow",      # or PIL
         "PyWavelets",  # for whash
     ],

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import sys
 
 try:
     from setuptools import setup
@@ -10,12 +11,16 @@ long_description = ""
 with open('README.rst') as f:
     long_description = f.read()
 
+# Fixes a version conflict between numpy and scipy on python 3.9+
+scipy = "scipy" if sys.version_info < (3, 9) else "scipy>=1.7"
+
 setup(
     name='ImageHash',
     version='4.2.1',
     author='Johannes Buchner',
     author_email='buchner.johannes@gmx.at',
-    py_modules=['imagehash'],
+    packages=['imagehash'],
+    package_data={'imagehash': ['py.typed']},
     data_files=[('images', ['tests/data/imagehash.png'])],
     scripts=['find_similar_images.py'],
     url='https://github.com/JohannesBuchner/imagehash',
@@ -26,7 +31,7 @@ setup(
     install_requires=[
         "six",
         "numpy",
-        "scipy",       # for phash
+        scipy,       # for phash
         "pillow",      # or PIL
         "PyWavelets",  # for whash
     ],

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import sys
 
 try:
     from setuptools import setup
@@ -10,9 +9,6 @@ except:
 long_description = ""
 with open('README.rst') as f:
     long_description = f.read()
-
-# Fixes a version conflict between numpy and scipy on python 3.9+
-scipy = "scipy" if sys.version_info < (3, 9) else "scipy>=1.7"
 
 setup(
     name='ImageHash',
@@ -31,7 +27,7 @@ setup(
     install_requires=[
         "six",
         "numpy",
-        scipy,       # for phash
+        'scipy',       # for phash
         "pillow",      # or PIL
         "PyWavelets",  # for whash
     ],


### PR DESCRIPTION
Closes #151

Just like #161, but addresses @JohannesBuchner concerns https://github.com/JohannesBuchner/imagehash/issues/151#issuecomment-977853870

> I am wondering how to do this with the least amount of future maintenance effort. I am worried that the stub file may become outdated if not care is taken.

The refactor from a single file module to a package was necessary for the inclusion of `py.typed`, which lets type checkers know to not look for type stubs as types are inlined.
See: https://peps.python.org/pep-0561/#packaging-type-information