### PR TITLE
Replace py_modules by packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
 	version='4.2.1',
 	author='Johannes Buchner',
 	author_email='buchner.johannes@gmx.at',
-	py_modules=['imagehash'],
+	packages=['imagehash'],
 	package_data={'imagehash': ['py.typed']},
 	data_files=[('images', ['tests/data/imagehash.png'])],
 	scripts=['find_similar_images.py'],


### PR DESCRIPTION
Not sure how that slipped through. But needed to be installed correctly now that this is a package and not a single-file module