### PR TITLE
Rename `scipy.fftpack` to `scipy.fft`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ black & gray fractions (without position information).
 Installation
 ============
 
-Based on PIL/Pillow Image, numpy and scipy.fftpack (for pHash)
+Based on PIL/Pillow Image, numpy and scipy.fft (for pHash)
 Easy installation through `pypi`_::
 
 	pip install imagehash

--- a/imagehash/__init__.py
+++ b/imagehash/__init__.py
@@ -270,11 +270,11 @@ def phash(image, hash_size=8, highfreq_factor=4):
 	if hash_size < 2:
 		raise ValueError('Hash size must be greater than or equal to 2')
 
-	import scipy.fftpack
+	import scipy.fft
 	img_size = hash_size * highfreq_factor
 	image = image.convert('L').resize((img_size, img_size), ANTIALIAS)
 	pixels = numpy.asarray(image)
-	dct = scipy.fftpack.dct(scipy.fftpack.dct(pixels, axis=0), axis=1)
+	dct = scipy.fft.dct(scipy.fft.dct(pixels, axis=0), axis=1)
 	dctlowfreq = dct[:hash_size, :hash_size]
 	med = numpy.median(dctlowfreq)
 	diff = dctlowfreq > med
@@ -290,11 +290,11 @@ def phash_simple(image, hash_size=8, highfreq_factor=4):
 
 	@image must be a PIL instance.
 	"""
-	import scipy.fftpack
+	import scipy.fft
 	img_size = hash_size * highfreq_factor
 	image = image.convert('L').resize((img_size, img_size), ANTIALIAS)
 	pixels = numpy.asarray(image)
-	dct = scipy.fftpack.dct(pixels)
+	dct = scipy.fft.dct(pixels)
 	dctlowfreq = dct[:hash_size, 1:hash_size + 1]
 	avg = dctlowfreq.mean()
 	diff = dctlowfreq > avg


### PR DESCRIPTION
## Change

* Rename `scipy.fftpack` to `scipy.fft`

## Reference

> This submodule is considered legacy and will no longer receive updates. This could also mean it will be removed in future SciPy versions. New code should use scipy.fft.

Source: https://docs.scipy.org/doc/scipy/reference/fftpack.html

Closes #108