### PR TITLE
colorhash: overflow encountered in scalar multiply

### DIFF
--- a/imagehash/__init__.py
+++ b/imagehash/__init__.py
@@ -438,7 +438,7 @@ def colorhash(image, binbits=3):
 	maxvalue = 2**binbits
 	values = [min(maxvalue - 1, int(frac_black * maxvalue)), min(maxvalue - 1, int(frac_gray * maxvalue))]
 	for counts in list(h_faint_counts) + list(h_bright_counts):
-		values.append(min(maxvalue - 1, int(counts) * maxvalue * 1. / c))
+		values.append(min(maxvalue - 1, int(counts / c * maxvalue)))
 	# print(values)
 	bitarray = []
 	for v in values:

--- a/imagehash/__init__.py
+++ b/imagehash/__init__.py
@@ -438,7 +438,7 @@ def colorhash(image, binbits=3):
 	maxvalue = 2**binbits
 	values = [min(maxvalue - 1, int(frac_black * maxvalue)), min(maxvalue - 1, int(frac_gray * maxvalue))]
 	for counts in list(h_faint_counts) + list(h_bright_counts):
-		values.append(min(maxvalue - 1, int(counts * maxvalue * 1. / c)))
+		values.append(min(maxvalue - 1, int(counts) * maxvalue * 1. / c))
 	# print(values)
 	bitarray = []
 	for v in values:


### PR DESCRIPTION
I noticed a small problem in the color hashing algo for HSV. When the bin bits increase to size 46 and onwards it gives a warning of scalar multiplication and due to this we get a slightly wrong answer. 

The warning: 
```
/imagehash/__init__.py:441: RuntimeWarning: overflow encountered in scalar multiply
  values.append(min(maxvalue - 1, int(counts * maxvalue * 1. / c)))
```

Peppers image bin bit size 46 (with fix) 
```
0ffffffffff07fffffffffe0ffffffffff40fffffffffd000ffffffffc07ffffffffc0001fffffff83fffffffffeffffffffffec01ffffffffd00000000000000000000000000000000000fffffffffff 
```

Peppers image bin bit size 46 (without fix)
```
0ffffffffff07fffffffffe0ffffffffff40fffffffffd000ffffffffc07ffffffffc0001fffffff83fffffffffefffffffffff001ffffffffd00000000000000000000000000000000000fffffffffff
```

Key Difference:
At Position 108–119 (starting from index 0):
With Fix: `feffffffffffec01`
Without Fix: `fffffffffff001`

The fix: we just needed to round off the `counts` variable  before performing other calculations.