### PR TITLE
fix: handle empty ImageMultiHash in hash_diff

### DIFF
--- a/imagehash/__init__.py
+++ b/imagehash/__init__.py
@@ -497,6 +497,8 @@ class ImageMultiHash:
 		:param bit_error_rate: Percentage of bits which can be incorrect, an alternative to the hamming cutoff. The
 		default of 0.25 means that the segment hashes can be up to 25% different
 		"""
+		if not self.segment_hashes or not other_hash.segment_hashes:
+			return 0, 0
 		# Set default hamming cutoff if it's not set.
 		if hamming_cutoff is None:
 			if bit_error_rate is None:

--- a/tests/test_empty_multihash.py
+++ b/tests/test_empty_multihash.py
@@ -1,0 +1,14 @@
+import unittest
+
+import imagehash
+
+
+class TestEmptyMultiHash(unittest.TestCase):
+    def test_hash_diff_empty_segments(self):
+        empty = imagehash.ImageMultiHash([])
+        other = imagehash.hex_to_multihash('aa' * 8)
+        self.assertEqual(empty.hash_diff(other), (0, 0))
+        self.assertEqual(other.hash_diff(empty), (0, 0))
+        self.assertEqual(empty.hash_diff(empty), (0, 0))
+        self.assertEqual(empty - other, 0.0)
+        self.assertFalse(empty.matches(other))


### PR DESCRIPTION
ImageMultiHash.hash_diff hits IndexError when empty segment_hashes. This PR fixes the regression with a focused test covering the case.
