### PR TITLE
fix: handle empty images in whash

### DIFF
--- a/imagehash/__init__.py
+++ b/imagehash/__init__.py
@@ -359,6 +359,9 @@ def whash(image, hash_size=8, image_scale=None, mode='haar', remove_max_haar_ll=
 	@remove_max_haar_ll - remove the lowest low level (LL) frequency using Haar wavelet.
 	"""
 	import pywt
+	# Empty images have no scale; match average_hash by returning a zero hash.
+	if min(image.size) == 0:
+		return ImageHash(numpy.zeros((hash_size, hash_size), dtype=bool))
 	if image_scale is not None:
 		assert image_scale & (image_scale - 1) == 0, 'image_scale is not power of 2'
 	else:

--- a/tests/test_whash.py
+++ b/tests/test_whash.py
@@ -47,6 +47,13 @@ class Test(unittest.TestCase):
 			hash = imagehash.whash(image)
 			self.assertEqual(hash.hash.size, default_hash_size**2)
 
+	def test_empty_image(self):
+		image = Image.new('RGB', (10, 10), 'white').crop((5, 5, 5, 5))
+		hash = imagehash.whash(image)
+		self.assertEqual(image.size, (0, 0))
+		self.assertEqual(hash.hash.size, 8**2)
+		self.assertEqual(str(hash), '0' * 16)
+
 	def test_hash_size_not_2power(self):
 		emsg = 'hash_size is not power of 2'
 		for hash_size in [3, 7, 12]:


### PR DESCRIPTION
imagehash.whash hits OverflowError when 0x0 empty PIL image. This PR fixes the regression with a focused test covering the case.
