### PR TITLE
fix: handle empty images in colorhash

### DIFF
--- a/imagehash/__init__.py
+++ b/imagehash/__init__.py
@@ -409,6 +409,10 @@ def colorhash(image, binbits=3):
 
 	# bin in hsv space:
 	intensity = numpy.asarray(image.convert('L')).flatten()
+	# Empty images have no pixels; match average_hash by returning a zero hash.
+	if intensity.size == 0:
+		bitarray = [0] * ((2 + 6 * 2) * binbits)
+		return ImageHash(numpy.asarray(bitarray).reshape((-1, binbits)))
 	h, s, v = [numpy.asarray(v).flatten() for v in image.convert('HSV').split()]
 	# black bin
 	mask_black = intensity < 256 // 8

--- a/tests/test_colorhash.py
+++ b/tests/test_colorhash.py
@@ -40,6 +40,14 @@ class Test(TestImageHash):
 	def test_colorhash_size(self):
 		self.check_hash_size(self.func, self.image)
 
+	def test_empty_image(self):
+		from PIL import Image
+		image = Image.new('RGB', (10, 10), 'white').crop((5, 5, 5, 5))
+		image_hash = imagehash.colorhash(image)
+		self.assertEqual(image.size, (0, 0))
+		self.assertEqual(image_hash.hash.size, (2 + 6 * 2) * 3)
+		self.assertEqual(str(image_hash), '00000000000')
+
 	def check_hash_stored(self, func, image, binbits=CHECK_HASH_DEFAULT):
 		for bit in binbits:
 			image_hash = func(image, bit)


### PR DESCRIPTION
imagehash.colorhash hits ValueError when 0x0 empty PIL image NaN. This PR fixes the regression with a focused test covering the case.
